### PR TITLE
puma.rbのソケットを作成する位置を修正

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,8 +1,11 @@
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
-threads threads_count, threads_count
-port        ENV.fetch("PORT") { 3000 }
-environment ENV.fetch("RAILS_ENV") { "development" }
-plugin :tmp_restart
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
 
-app_root = File.expand_path("../..", __FILE__)
-bind "unix://#{app_root}/tmp/sockets/puma.sock"
+bind "unix:///var/www/portfolio/tmp/sockets/puma.sock"
+
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+
+plugin :tmp_restart


### PR DESCRIPTION
本番環境で502 Bad Gatewayが発生している問題で、本番環境のnginxの設定とpuma.rbのソケットの位置が一致していなかったため修正しました。